### PR TITLE
Add HPU Readme note

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,70 @@ then finetuned on 512x512 images.
 in its training data.
 Details on the training procedure and data, as well as the intended use of the model can be found in the corresponding [model card](https://huggingface.co/CompVis/stable-diffusion).
 
+## Stable Diffusion Integration with Intel® Gaudi® HPU
+
+Stable Diffusion has been successfully integrated with Intel® Gaudi® HPUs, enabling high-performance text-to-image generation and image modifications on Habana’s specialized AI hardware. This enhancement leverages Habana’s optimized PyTorch environment to maximize efficiency and scalability for AI workloads.
+
+### Key Features of Intel® Gaudi® HPU Integration:
+
+- **Efficient Sampling:** The integration utilizes Habana’s HPU-specific optimizations for accelerated Stable Diffusion pipeline execution.
+- **Reduced Latency:** Support for HPU graphs and Habana’s framework reduces the latency of inference workflows.
+- **Dockerized Environment:** Provides a pre-configured Docker environment for seamless setup and deployment.
+- **Compatibility with Diffusers Library:** Easy integration with Hugging Face’s Diffusers library for streamlined development.
+
+### How to Use Stable Diffusion with Intel® Gaudi® HPUs:
+
+#### Setup the Environment
+1. **Build the Docker Image:**
+   ```bash
+   docker build -t sd_hpu:latest -f Dockerfile.hpu .
+   ```
+   Use the `vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest` base image, ensuring compatibility with your system configuration.
+
+2. **Run the Container:**
+   ```bash
+   docker run -it --runtime=habana sd_hpu:latest
+   ```
+   Optionally, map your local project directory into the container using the `-v` flag.
+
+#### Running Stable Diffusion on HPU
+
+For inference using the Diffusers library:
+
+```python
+from torch import autocast, device
+from diffusers import StableDiffusionPipeline
+import habana_frameworks.torch.core as htcore
+from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+
+# Load the pipeline
+pipe = StableDiffusionPipeline.from_pretrained(
+    "CompVis/stable-diffusion-v1-4",
+    use_auth_token=True
+)
+
+# Enable HPU graph optimization and move the pipeline to HPU
+gpu_pipe = wrap_in_hpu_graph(pipe)
+gpu_pipe = pipe.to(device("hpu")).eval()
+
+prompt = "a futuristic cityscape under a starry sky"
+image = gpu_pipe(prompt).images[0]
+image.save("output_hpu.png")
+```
+
+For image modification tasks, use the following command:
+
+```bash
+python scripts/img2img.py --prompt "A surreal dreamscape" --init-img <path-to-img.jpg> --strength 0.8 --device hpu
+```
+
+### Additional Notes
+
+- Ensure that the required models and checkpoints are available in their respective directories.
+- Refer to the [Habana AI Developer Documentation](https://docs.habana.ai/en/latest/index.html) for further guidance on HPU-specific optimizations and troubleshooting.
+
+With this integration, developers can now harness the power of Intel® Gaudi® HPUs for Stable Diffusion workflows, enabling cutting-edge generative AI tasks with optimized performance and scalability.
+
 ## Comments
 
 - Our code base for the diffusion models builds heavily on [OpenAI's ADM codebase](https://github.com/openai/guided-diffusion)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,54 @@ Please see the [Post-Processing Documentation](https://sygil-dev.github.io/sygil
 [Patrick Esser](https://github.com/pesser),
 [Björn Ommer](https://hci.iwr.uni-heidelberg.de/Staff/bommer)
 
+
+## Diffusers Integration on Intel® Gaudi® HPU
+
+A simple way to download and sample Stable Diffusion is by using the [diffusers library](https://github.com/huggingface/diffusers/tree/main#new--stable-diffusion-is-now-fully-compatible-with-diffusers):
+
+```python
+from torch import autocast
+import time
+from optimum.habana.diffusers import GaudiDDIMScheduler, GaudiStableDiffusionPipeline
+
+model_name = "CompVis/stable-diffusion-v1-4"
+
+scheduler = GaudiDDIMScheduler.from_pretrained(model_name, subfolder="scheduler")
+
+pipe = GaudiStableDiffusionPipeline.from_pretrained(
+    model_name,
+    scheduler=scheduler,
+    use_habana=True,
+    use_hpu_graphs=True,
+    gaudi_config="Habana/stable-diffusion",
+)
+
+from habana_frameworks.torch.utils.library_loader import load_habana_module
+from optimum.habana.transformers.modeling_utils import adapt_transformers_to_gaudi
+load_habana_module()
+
+# Adapt transformers models to Gaudi for optimization
+adapt_transformers_to_gaudi()
+
+pipe = pipe.to("hpu")
+
+prompt = "a photo of an astronaut riding a horse on mars"
+
+with autocast("hpu"):
+    t1 = time.perf_counter()
+    upscaled_image = pipe(
+        prompt=[prompt],
+        num_images_per_prompt=2,
+        batch_size=4,
+        output_type="pil",
+    ).images[0]
+
+upscaled_image.save("astronaut_rides_horse.png")
+print(f"Time taken: {time.perf_counter() - t1:.2f}s")
+```
+
+Note: This information has also been added to the Stable Diffusion core repository.
+
 **CVPR '22 Oral**
 
 which is available on [GitHub](https://github.com/CompVis/latent-diffusion). PDF at [arXiv](https://arxiv.org/abs/2112.10752). Please also visit our [Project page](https://ommer-lab.com/research/latent-diffusion-models/).

--- a/README.md
+++ b/README.md
@@ -195,58 +195,60 @@ Details on the training procedure and data, as well as the intended use of the m
 
 Stable Diffusion has been successfully integrated with Intel® Gaudi® HPUs, enabling high-performance text-to-image generation and image modifications on Habana’s specialized AI hardware. This enhancement leverages Habana’s optimized PyTorch environment to maximize efficiency and scalability for AI workloads.
 
-### Key Features of Intel® Gaudi® HPU Integration:
+## Stable Diffusion Integration with Intel® Gaudi® HPU
 
-- **Efficient Sampling:** The integration utilizes Habana’s HPU-specific optimizations for accelerated Stable Diffusion pipeline execution.
-- **Reduced Latency:** Support for HPU graphs and Habana’s framework reduces the latency of inference workflows.
-- **Dockerized Environment:** Provides a pre-configured Docker environment for seamless setup and deployment.
-- **Compatibility with Diffusers Library:** Easy integration with Hugging Face’s Diffusers library for streamlined development.
+Stable Diffusion can be effectively run on Intel® Gaudi® HPUs, providing high-performance capabilities for deploying text-to-image generation systems in Dockerized environments. This approach is particularly valuable for frontend applications requiring real-time generative AI solutions. 
 
-### How to Use Stable Diffusion with Intel® Gaudi® HPUs:
+### Key Benefits of Intel® Gaudi® HPUs:
 
-#### Setup the Environment
-1. **Build the Docker Image:**
+- **Optimized Performance:** Intel® Gaudi® HPUs are designed for deep learning workloads, delivering efficient and scalable solutions for generative AI tasks.
+- **Docker Compatibility:** Pre-configured Docker containers make it easy to set up and deploy Stable Diffusion workflows.
+- **Cost Efficiency:** Lower training and inference costs compared to traditional GPU-based systems.
+- **Documentation and Support:** Comprehensive resources are available at [Intel® Gaudi® Documentation](https://docs.habana.ai/en/latest/index.html).
+
+### Running Stable Diffusion on Intel® Gaudi® HPUs with Docker
+
+#### Step 1: Prepare the Docker Environment
+
+Intel® provides prebuilt Docker images optimized for Gaudi® HPUs. Follow these steps to set up your environment:
+
+1. Pull the Base Image:
+   ```bash
+   docker pull vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest
+   ```
+
+2. Build a Docker Image for Stable Diffusion:
    ```bash
    docker build -t sd_hpu:latest -f Dockerfile.hpu .
    ```
-   Use the `vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest` base image, ensuring compatibility with your system configuration.
 
-2. **Run the Container:**
+3. Run the Docker Container:
    ```bash
    docker run -it --runtime=habana sd_hpu:latest
    ```
-   Optionally, map your local project directory into the container using the `-v` flag.
+   Use the `-v` option to mount local directories if needed.
 
-#### Running Stable Diffusion on HPU
+#### Step 2: Configure Stable Diffusion
 
-For inference using the Diffusers library:
+Inside the Docker container, configure and run Stable Diffusion pipelines. The Docker environment comes preloaded with Habana-specific optimizations, enabling seamless execution.
 
-```python
-from torch import autocast, device
-from diffusers import StableDiffusionPipeline
-import habana_frameworks.torch.core as htcore
-from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+### Exploring Habana’s Tools and Documentation
 
-# Load the pipeline
-pipe = StableDiffusionPipeline.from_pretrained(
-    "CompVis/stable-diffusion-v1-4",
-    use_auth_token=True
-)
+Habana’s tools, such as SynapseAI and Gaudi-specific libraries, are tailored to enhance the performance of AI models. Key resources include:
 
-# Enable HPU graph optimization and move the pipeline to HPU
-gpu_pipe = wrap_in_hpu_graph(pipe)
-gpu_pipe = pipe.to(device("hpu")).eval()
+- **Framework Integrations:** Optimized support for PyTorch and TensorFlow.
+- **HPU Graph Support:** Efficient execution for both training and inference workflows.
+- **Detailed Documentation:** Access the [Intel® Gaudi® Documentation](https://docs.habana.ai/en/latest/index.html) for technical insights, best practices, and troubleshooting.
 
-prompt = "a futuristic cityscape under a starry sky"
-image = gpu_pipe(prompt).images[0]
-image.save("output_hpu.png")
-```
+### Why Choose Intel® Gaudi® HPUs
 
-For image modification tasks, use the following command:
+Intel® Gaudi® HPUs empower developers to achieve real-time, low-latency performance for frontend AI applications. By leveraging Dockerized environments and Habana’s software stack, developers can:
 
-```bash
-python scripts/img2img.py --prompt "A surreal dreamscape" --init-img <path-to-img.jpg> --strength 0.8 --device hpu
-```
+- Quickly deploy AI solutions with minimal setup.
+- Optimize generative AI tasks for cost and efficiency.
+- Access a robust ecosystem of tools and resources.
+
+Incorporating Intel® Gaudi® HPUs into your AI workflows ensures that you stay ahead in delivering cutting-edge solutions for next-generation frontend applications.
 
 ### Additional Notes
 


### PR DESCRIPTION
runetime logs:
```bash
============================= HABANA PT BRIDGE CONFIGURATION =========================== 
 PT_HPU_LAZY_MODE = 1
 PT_RECIPE_CACHE_PATH = 
 PT_CACHE_FOLDER_DELETE = 0
 PT_HPU_RECIPE_CACHE_CONFIG = 
 PT_HPU_MAX_COMPOUND_OP_SIZE = 9223372036854775807
 PT_HPU_LAZY_ACC_PAR_MODE = 1
 PT_HPU_ENABLE_REFINE_DYNAMIC_SHAPES = 0
 PT_HPU_EAGER_PIPELINE_ENABLE = 1
 PT_HPU_EAGER_COLLECTIVE_PIPELINE_ENABLE = 1
---------------------------: System Configuration :---------------------------
Num CPU Cores : 152
CPU RAM       : 1056439544 KB
------------------------------------------------------------------------------
/usr/local/lib/python3.10/dist-packages/transformers/deepspeed.py:24: FutureWarning: transformers.deepspeed module is deprecated and will be removed in a future version. Please import deepspeed modules directly from transformers.integrations
  warnings.warn(
Loading Habana modules from /usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/lib
[INFO|pipeline_stable_diffusion.py:415] 2025-02-28 20:42:28,927 >> 1 prompt(s) received, 2 generation(s) per prompt, 4 sample(s) per batch, 1 total batch(es).
[WARNING|pipeline_stable_diffusion.py:420] 2025-02-28 20:42:28,927 >> The first two iterations are slower so it is recommended to feed more batches.
  0%|                                                                                                                                                                                                | 0/1 [00:00<?, ?it/s]/usr/local/lib/python3.10/dist-packages/diffusers/models/unets/unet_2d_blocks.py:1369: FutureWarning: `scale` is deprecated and will be removed in version 1.0.0. The `scale` argument is deprecated and will be ignored. Please remove it, as passing it will raise an error in the future. `scale` should directly be passed while calling the underlying pipeline component i.e., via `cross_attention_kwargs`.
  deprecate("scale", "1.0.0", deprecation_message)
/usr/local/lib/python3.10/dist-packages/diffusers/models/unets/unet_2d_blocks.py:2628: FutureWarning: `scale` is deprecated and will be removed in version 1.0.0. The `scale` argument is deprecated and will be ignored. Please remove it, as passing it will raise an error in the future. `scale` should directly be passed while calling the underlying pipeline component i.e., via `cross_attention_kwargs`.
  deprecate("scale", "1.0.0", deprecation_message)
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [01:39<00:00, 99.63s/it]
[INFO|pipeline_stable_diffusion.py:610] 2025-02-28 20:44:08,753 >> Speed metrics: {'generation_runtime': 99.6278, 'generation_samples_per_second': 0.736, 'generation_steps_per_second': 36.821}
Time taken: 169.32s
```